### PR TITLE
Fix 'null' bodies when activating case files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 
+## [2.1.1] - 2021-03-04
+### Fixed
+- Fixed a bug that caused case file activation to fail
+
+
 ## [2.1.0] - 2020-11-11
 ### Added
 - Added support for specifying which type of SSN signers should validate as.

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -295,7 +295,7 @@ abstract class Entity
     {
         $url  = $parent->getRelativeUrl() . '/' . $parent->getId() . '/' . $actionName;
 
-        $response = ApiConnector::callServer($url, json_encode($data), $method);
+        $response = ApiConnector::callServer($url, $data !== null ? json_encode($data) : null, $method);
         if (!$response) {
             throw new Exception('Penneo: Internal problem encountered calling action: ' . $actionName);
         }


### PR DESCRIPTION
This was causing the API to reject the `/send` calls with `400 Bad Request`.