### PR TITLE
SIGN-652 Add the storeAsContact setting on signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 
+## 2.4.0 - 2022-10-31
+### Added
+- Added the `storeAsContact` property to signers
+
+
 ## 2.3.0 - 2021-05-26
 ### Changed
 - Specification of `composer.json` changed to accept `php:^8.0`

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -10,14 +10,16 @@ class Signer extends Entity
             'socialSecurityNumberPlain',
             'ssnType',
             'vatin',
-            'onBehalfOf'
+            'onBehalfOf',
+            'storeAsContact'
         ),
         'update' => array(
             'name',
             'socialSecurityNumberPlain',
             'ssnType',
             'vatin',
-            'onBehalfOf'
+            'onBehalfOf',
+            'storeAsContact'
         )
     );
     protected static $relativeUrl = 'signers';
@@ -34,6 +36,9 @@ class Signer extends Entity
     protected $onBehalfOf;
     /** @var string|null */
     protected $vatin;
+    /** @var bool|null */
+    protected $storeAsContact;
+
 
     /** @var CaseFile */
     protected $caseFile;
@@ -131,6 +136,22 @@ class Signer extends Entity
     public function setOnBehalfOf(string $onBehalfOf)
     {
         $this->onBehalfOf = $onBehalfOf;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getStoreAsContact(): ?bool
+    {
+        return $this->storeAsContact;
+    }
+
+    /**
+     * @param bool|null $storeAsContact
+     */
+    public function setStoreAsContact(?bool $storeAsContact): void
+    {
+        $this->storeAsContact = $storeAsContact;
     }
 
     public function addSignerType(SignerType $type): bool


### PR DESCRIPTION
This PR will make it possible to set the `storeAsContact` value on Signer objects. 