### PR TITLE
Update psr/log to suppot newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "psr/log": "~1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
Updated dependencies to allow PSR\Log version 1.x through 3.x, since no breaking changes between versions in code. Some newer packages require newer versions of PSR\Log and can therefore not be used in same workspace as this currently