### PR TITLE
Add insecureSigningMethods to SigningRequest model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `insecureSigningMethods` to SigningRequest allowing for finer control over which simple electronic signature methods
 should be available to a signer
 ```php
-$signingRequest->setInsecureSigningMethods(['draw', 'text', 'image']);
+$signingRequest->setInsecureSigningMethods([InsecureSigningMethods::DRAW, InsecureSigningMethods::IMAGE, InsecureSigningMethods::TEXT]);
 ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Removed
 
+## 2.5.0 - 2023-05-23
+### Added
+- Added `insecureSigningMethods` to SigningRequest allowing for finer control over which simple electronic signature methods
+should be available to a signer
+```php
+$signingRequest->setInsecureSigningMethods(['draw', 'text', 'image']);
+```
+
+
 ## 2.4.2 - 2022-12-22
 ### Fixed
 - Fixed "Calling method X on null" issues: https://github.com/Penneo/sdk-php/issues/66

--- a/src/InsecureSigningMethods.php
+++ b/src/InsecureSigningMethods.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Penneo\SDK;
+
+class InsecureSigningMethods
+{
+    public const DRAW = 'draw';
+    public const IMAGE = 'image';
+    public const TEXT = 'text';
+}

--- a/src/SigningRequest.php
+++ b/src/SigningRequest.php
@@ -43,8 +43,10 @@ class SigningRequest extends Entity
     protected $enableInsecureSigning;
 
     /**
-     * The simple electronic signing methods that the signer can use to make a simple electronic signature
-     * @var array<string>|null $insecureSigningMethods
+     * The simple electronic signing methods that the signer
+     * can use to make a simple electronic signature
+     *
+     * @var array<"draw" | "image" | "text">|null $insecureSigningMethods
      */
     protected $insecureSigningMethods;
 
@@ -221,14 +223,27 @@ class SigningRequest extends Entity
 
     /**
      * See InsecureSigningMethods class for possible values
-     * @param array<"draw" | "image" | "text">|null $insecureSigningMethods
+     *
+     * @param  array<"draw" | "image" | "text">|null $insecureSigningMethods
+     * @return void
      */
     public function setInsecureSigningMethods(?array $insecureSigningMethods): void
     {
         if ($insecureSigningMethods !== null) {
             foreach ($insecureSigningMethods as $method) {
-                if (!in_array($method, [InsecureSigningMethods::DRAW, InsecureSigningMethods::IMAGE, InsecureSigningMethods::TEXT], true)) {
-                    throw new InvalidArgumentException('Invalid signing method: ' . $method);
+                if (
+                    !in_array(
+                        $method,
+                        [
+                        InsecureSigningMethods::DRAW,
+                        InsecureSigningMethods::IMAGE,
+                        InsecureSigningMethods::TEXT],
+                        true
+                    )
+                ) {
+                    throw new InvalidArgumentException(
+                        'Invalid signing method: ' . $method
+                    );
                 }
             }
         }

--- a/src/SigningRequest.php
+++ b/src/SigningRequest.php
@@ -2,7 +2,7 @@
 
 namespace Penneo\SDK;
 
-use Penneo\SDK\Entity;
+use InvalidArgumentException;
 
 class SigningRequest extends Entity
 {
@@ -41,6 +41,11 @@ class SigningRequest extends Entity
     protected $reminderInterval;
     protected $accessControl;
     protected $enableInsecureSigning;
+
+    /**
+     * The simple electronic signing methods that the signer can use to make a simple electronic signature
+     * @var array<string>|null $insecureSigningMethods
+     */
     protected $insecureSigningMethods;
 
     public function getLink()
@@ -215,10 +220,19 @@ class SigningRequest extends Entity
     }
 
     /**
-     * @param array<string>|null $insecureSigningMethods
+     * See InsecureSigningMethods class for possible values
+     * @param array<"draw" | "image" | "text">|null $insecureSigningMethods
      */
     public function setInsecureSigningMethods(?array $insecureSigningMethods): void
     {
+        if ($insecureSigningMethods !== null) {
+            foreach ($insecureSigningMethods as $method) {
+                if (!in_array($method, [InsecureSigningMethods::DRAW, InsecureSigningMethods::IMAGE, InsecureSigningMethods::TEXT], true)) {
+                    throw new InvalidArgumentException('Invalid signing method: ' . $method);
+                }
+            }
+        }
+
         $this->insecureSigningMethods = $insecureSigningMethods;
     }
 }

--- a/src/SigningRequest.php
+++ b/src/SigningRequest.php
@@ -20,7 +20,8 @@ class SigningRequest extends Entity
             'failUrl',
             'reminderInterval',
             'accessControl',
-            'enableInsecureSigning'
+            'enableInsecureSigning',
+            'insecureSigningMethods',
         )
     );
     protected static $relativeUrl = 'signingrequests';
@@ -40,6 +41,7 @@ class SigningRequest extends Entity
     protected $reminderInterval;
     protected $accessControl;
     protected $enableInsecureSigning;
+    protected $insecureSigningMethods;
 
     public function getLink()
     {
@@ -205,5 +207,18 @@ class SigningRequest extends Entity
     public function setEnableInsecureSigning($enableInsecureSigning)
     {
         $this->enableInsecureSigning = $enableInsecureSigning;
+    }
+
+    public function getInsecureSigningMethods(): ?array
+    {
+        return $this->insecureSigningMethods;
+    }
+
+    /**
+     * @param array<string>|null $insecureSigningMethods
+     */
+    public function setInsecureSigningMethods(?array $insecureSigningMethods): void
+    {
+        $this->insecureSigningMethods = $insecureSigningMethods;
     }
 }


### PR DESCRIPTION
- Added `insecureSigningMethods` to SigningRequest allowing for finer control over which simple electronic signature methods should be available to a signer
```php
$signingRequest->setInsecureSigningMethods(['draw', 'text', 'image']);
```