### PR TITLE
fixed PHP warnings

### DIFF
--- a/tests/unit/ApiConnectorTest.php
+++ b/tests/unit/ApiConnectorTest.php
@@ -8,19 +8,24 @@ use Penneo\SDK\ApiConnector;
 use Penneo\SDK\OAuth\OAuth;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+use RuntimeException;
 
 class ApiConnectorTest extends TestCase
 {
+    /** @throws ReflectionException */
     public function tearDown(): void
     {
         $this->resetStaticProperties(ApiConnector::class);
         parent::tearDown();
     }
 
+    /** @throws ReflectionException */
     protected function resetStaticProperties(string $className)
     {
         $reflectedClass = new ReflectionClass($className);
-        $staticProperties = $reflectedClass->getProperties(\ReflectionProperty::IS_STATIC);
+        $staticProperties = $reflectedClass->getProperties(ReflectionProperty::IS_STATIC);
 
         foreach ($staticProperties as $property) {
             $property->setAccessible(true);
@@ -50,7 +55,7 @@ class ApiConnectorTest extends TestCase
                 $this->assertEquals('https', $request->getUri()->getScheme());
                 $this->assertEquals("/api/{$apiVersion}/something", $request->getUri()->getPath());
 
-                throw new \RuntimeException('cancel the request');
+                throw new RuntimeException('cancel the request');
             }
         );
 
@@ -64,7 +69,7 @@ class ApiConnectorTest extends TestCase
         ApiConnector::initializeOAuth($oauth, $apiVersion);
         try {
             ApiConnector::callServer('something', ['somebody' => 'oncetoldme'], 'get');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             if ($e->getMessage() !== 'cancel the request') {
                 throw $e;
             }

--- a/tests/unit/OAuth/OAuthApiTest.php
+++ b/tests/unit/OAuth/OAuthApiTest.php
@@ -14,6 +14,12 @@ class OAuthApiTest extends TestCase
 {
     use TestsEnvironments;
 
+    private $config;
+
+    private $client;
+
+    private $api;
+
     public function setUp(): void
     {
         $this->config = $this->createPartialMock(
@@ -46,7 +52,7 @@ class OAuthApiTest extends TestCase
         $this->config->method('getEnvironment')->willReturn($environment);
         $this->client->expects($this->once())
             ->method('post')
-            ->with("https://${expectedHostname}/oauth/token")
+            ->with("https://{$expectedHostname}/oauth/token")
             ->willReturn($this->successfulResponse());
 
         $this->api->postTokenRefresh();
@@ -59,7 +65,7 @@ class OAuthApiTest extends TestCase
 
         $this->client->expects($this->once())
             ->method('post')
-            ->with("https://${expectedHostname}/oauth/token")
+            ->with("https://{$expectedHostname}/oauth/token")
             ->willReturn($this->successfulResponse());
 
         $this->api->postCodeExchange('someCode', 'someVerifier');


### PR DESCRIPTION
This fixes some of the deprecation warnings which pop up when running unit tests.

`Deprecated: Using ${var} in strings is deprecated, use {$var} instead`

`Deprecated: Creation of dynamic property Penneo\SDK\Tests\Unit\OAuth\OAuthApiTest::$api is deprecated`
