### PR TITLE
Fix API key and secret in programmatic OAuth example

### DIFF
--- a/docs/programmatic_oauth_example.php
+++ b/docs/programmatic_oauth_example.php
@@ -20,7 +20,7 @@ $penneoOAuth = OAuthBuilder::start()
     ->setClientSecret('clientSecret')             // <-
     ->setTokenStorage($tokenStorage)
     ->setApiKey('apiKey')                         // <- the api credentials found in your
-    ->setApiKey('apiSecret')                      // <- penneo users settings
+    ->setApiSecret('apiSecret')                   // <- penneo users settings
     ->build();
 
 ApiConnector::initializeOAuth($penneoOAuth);


### PR DESCRIPTION
This pull request includes a minor but important fix in the `docs/programmatic_oauth_example.php` file. The change corrects the method name from `setApiKey` to `setApiSecret` for setting up the API secret. This will ensure that the API secret is correctly set during OAuth initialization.